### PR TITLE
Try to find git directory starting from current project directory

### DIFF
--- a/src/main/groovy/com/gladed/gradle/androidgitversion/AndroidGitVersion.groovy
+++ b/src/main/groovy/com/gladed/gradle/androidgitversion/AndroidGitVersion.groovy
@@ -125,7 +125,7 @@ class AndroidGitVersionExtension {
         try {
             repo = new FileRepositoryBuilder().
                     readEnvironment().
-                    findGitDir(project.rootDir).
+                    findGitDir(project.projectDir).
                     build()
         } catch (IllegalArgumentException e) {
             // No repo found


### PR DESCRIPTION
When leaf project is stored in submodule of root project we need to take
tags from submodule and not root repository.
