### PR TITLE
Initial suggestion for proposed feature to match git describe

### DIFF
--- a/src/main/groovy/com/gladed/androidgitversion/AndroidGitVersion.groovy
+++ b/src/main/groovy/com/gladed/androidgitversion/AndroidGitVersion.groovy
@@ -42,6 +42,11 @@ class AndroidGitVersion implements Plugin<Project> {
 
 class AndroidGitVersionExtension {
     /**
+    * Option to make versionName match the expected output for those using `git describe`
+    */
+    boolean matchGitDescribe = false
+
+    /**
      * Prefix used to specify special text before the tag. Useful in projects which manage
      * multiple external version names.
      */
@@ -130,6 +135,10 @@ class AndroidGitVersionExtension {
         if (!results) results = scan()
 
         String name = results.lastVersion
+
+        if (matchGitDescribe) {
+            return name
+        }
 
         if (name == "unknown") return name
         name = this.format
@@ -253,6 +262,10 @@ class AndroidGitVersionExtension {
                         .findResult{ x,y-> x<=>y ?: null } ?: b.size() <=> a.size()
                 }.
                 last()
+
+        if (matchGitDescribe) {
+            results.lastVersion = git.describe().call()
+        }
 
         results
     }

--- a/src/test/groovy/com/gladed/androidgitversion/MainTest.groovy
+++ b/src/test/groovy/com/gladed/androidgitversion/MainTest.groovy
@@ -161,6 +161,19 @@ class MainTest extends AndroidGitVersionTest {
         assertTrue("untracked is dirty", plugin.name().contains("dirty"))
     }
 
+    void testMatchGitDescribeOffByDefault() {
+        addCommit()
+        addTag("1.0.0")
+        def currentCommit = addCommit()
+        def currentHash = ObjectId.toString(currentCommit.toObjectId())
+        def shortHash = currentHash.substring(0, 7)
+        def expectedVersionName = "1.0.0-1-" + shortHash
+        def versionName = plugin.name()
+        assert versionName.startsWith("1.0.0-1-")
+        assert versionName.endsWith(shortHash)
+        assertEquals (expectedVersionName, versionName)
+    }
+
     void testMatchGitDescribeUsesCorrectCommit() {
         plugin.matchGitDescribe = true
         addCommit()

--- a/src/test/groovy/com/gladed/androidgitversion/MainTest.groovy
+++ b/src/test/groovy/com/gladed/androidgitversion/MainTest.groovy
@@ -1,6 +1,7 @@
 package com.gladed.androidgitversion
 
 import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.lib.ObjectId
 import org.eclipse.jgit.lib.Repository
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
@@ -158,6 +159,20 @@ class MainTest extends AndroidGitVersionTest {
         File file = new File(projectFolder.root, "untracked.file");
         file.append("content");
         assertTrue("untracked is dirty", plugin.name().contains("dirty"))
+    }
+
+    void testMatchGitDescribeUsesCorrectCommit() {
+        plugin.matchGitDescribe = true
+        addCommit()
+        addTag("1.0.0")
+        def currentCommit = addCommit()
+        def currentHash = ObjectId.toString(currentCommit.toObjectId())
+        def shortHash = currentHash.substring(0, 7)
+        def expectedVersionName = "1.0.0-1-g" + shortHash
+        def versionName = plugin.name()
+        assert versionName.startsWith("1.0.0-1-g")
+        assert versionName.endsWith(shortHash)
+        assertEquals (expectedVersionName, versionName)
     }
 
     void testFlush() {


### PR DESCRIPTION
In response to issue #67 this branch/PR is an initial suggestion on a general direction that could be taken in order to resolve the issue and any others (such as issue #66) where users are anticipating the versionName to more closely match the output of the `git describe` command.