### PR TITLE
Match git describe

### DIFF
--- a/src/main/groovy/com/gladed/androidgitversion/AndroidGitVersion.groovy
+++ b/src/main/groovy/com/gladed/androidgitversion/AndroidGitVersion.groovy
@@ -136,9 +136,6 @@ class AndroidGitVersionExtension {
 
         String name = results.lastVersion
 
-        if (matchGitDescribe) {
-            return name
-        }
 
         if (name == "unknown") return name
         name = this.format
@@ -263,8 +260,8 @@ class AndroidGitVersionExtension {
                 }.
                 last()
 
-        if (matchGitDescribe) {
-            results.lastVersion = git.describe().call()
+        if (matchGitDescribe && this.format.contains("%tag%%-count%%-commit%")) {
+            this.format = this.format.replace("%tag%%-count%%-commit%", git.describe().call())
         }
 
         results

--- a/src/main/groovy/com/gladed/androidgitversion/AndroidGitVersion.groovy
+++ b/src/main/groovy/com/gladed/androidgitversion/AndroidGitVersion.groovy
@@ -42,6 +42,11 @@ class AndroidGitVersion implements Plugin<Project> {
 
 class AndroidGitVersionExtension {
     /**
+    * Option to make versionName match the expected output for those using `git describe`
+    */
+    boolean matchGitDescribe = false
+
+    /**
      * Prefix used to specify special text before the tag. Useful in projects which manage
      * multiple external version names.
      */
@@ -130,6 +135,10 @@ class AndroidGitVersionExtension {
         if (!results) results = scan()
 
         String name = results.lastVersion
+
+        if (matchGitDescribe) {
+            return name
+        }
 
         if (name == "unknown") return name
         name = this.format
@@ -253,6 +262,10 @@ class AndroidGitVersionExtension {
                         .findResult{ x,y-> x<=>y ?: null } ?: b.size() <=> a.size()
                 }.
                 last()
+
+        if (matchGitDescribe) {
+            results.lastVersion = git.describe().call()
+        }
 
         results
     }

--- a/src/test/groovy/com/gladed/androidgitversion/FormatTest.groovy
+++ b/src/test/groovy/com/gladed/androidgitversion/FormatTest.groovy
@@ -30,6 +30,40 @@ class FormatTest extends AndroidGitVersionTest {
         assert plugin.name().endsWith(').release_1.x')
     }
 
+    void testBranchNameOnGitDescribe() {
+        plugin.matchGitDescribe = true
+        addCommit()
+        addTag("1.0")
+        addBranch("feature-foo")
+        new File(projectFolder.root, "build.gradle").append("// addition 1")
+        addCommit()
+
+        assert plugin.name().startsWith('1.0-1-g')
+        assert plugin.name().endsWith('-feature-foo')
+    }
+
+    void testDirtyOnGitDescribe() {
+        plugin.matchGitDescribe = true
+        addCommit()
+        addTag("1.0")
+        new File(projectFolder.root, "build.gradle").append("// addition 2") // Dirty
+
+        assert plugin.name().equals("1.0-dirty")
+    }
+
+    void testDirtyBranchOnGitDescribe() {
+        this.plugin.matchGitDescribe = true
+        addCommit()
+        addTag("1.0")
+        addBranch("release/1.x")
+        new File(projectFolder.root, "build.gradle").append("// addition 1")
+        addCommit()
+        new File(projectFolder.root, "build.gradle").append("// addition 2") // Dirty
+
+        assert plugin.name().startsWith('1.0-1-g')
+        assert plugin.name().endsWith('release_1.x-dirty')
+    }
+
     void testLongCommitHash() {
         addCommit()
         addTag("1.4")

--- a/src/test/groovy/com/gladed/androidgitversion/MainTest.groovy
+++ b/src/test/groovy/com/gladed/androidgitversion/MainTest.groovy
@@ -161,6 +161,19 @@ class MainTest extends AndroidGitVersionTest {
         assertTrue("untracked is dirty", plugin.name().contains("dirty"))
     }
 
+    void testMatchGitDescribeOffByDefault() {
+        addCommit()
+        addTag("1.0.0")
+        def currentCommit = addCommit()
+        def currentHash = ObjectId.toString(currentCommit.toObjectId())
+        def shortHash = currentHash.substring(0, 7)
+        def expectedVersionName = "1.0.0-1-" + shortHash
+        def versionName = plugin.name()
+        assert versionName.startsWith("1.0.0-1-")
+        assert versionName.endsWith(shortHash)
+        assertEquals (expectedVersionName, versionName)
+    }
+
     void testMatchGitDescribeUsesCorrectCommit() {
         plugin.matchGitDescribe = true
         addCommit()

--- a/src/test/groovy/com/gladed/androidgitversion/MainTest.groovy
+++ b/src/test/groovy/com/gladed/androidgitversion/MainTest.groovy
@@ -1,6 +1,7 @@
 package com.gladed.androidgitversion
 
 import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.lib.ObjectId
 import org.eclipse.jgit.lib.Repository
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
@@ -158,6 +159,20 @@ class MainTest extends AndroidGitVersionTest {
         File file = new File(projectFolder.root, "untracked.file");
         file.append("content");
         assertTrue("untracked is dirty", plugin.name().contains("dirty"))
+    }
+
+    void testMatchGitDescribeUsesCorrectCommit() {
+        plugin.matchGitDescribe = true
+        addCommit()
+        addTag("1.0.0")
+        def currentCommit = addCommit()
+        def currentHash = ObjectId.toString(currentCommit.toObjectId())
+        def shortHash = currentHash.substring(0, 7)
+        def expectedVersionName = "1.0.0-1-g" + shortHash
+        def versionName = plugin.name()
+        assert versionName.startsWith("1.0.0-1-g")
+        assert versionName.endsWith(shortHash)
+        assertEquals (expectedVersionName, versionName)
     }
 
     void testFlush() {


### PR DESCRIPTION
This should be a (more) viable option for supporting `git describe`. It builds on top of #68 which had significant breakages when `matchGitDescribe` was set to true. For example, the code completely hopped over the `format` options and therefore the branch name and the designation of "dirty" were never considered/included.

Those issues are now solved by only using the output of `git describe` for those who have 1) set it to true AND 2) included an exact string in their format.

Note: The aforementioned string is `"%tag%%-count%%-commit%"` and given that *is* included in the default `format` string, I am about to work on some new changes which should pre-empt any concerns about turning on matchGitDescribe without modifying `format`.