### PR TITLE
Match git describe using format

### DIFF
--- a/src/main/groovy/com/gladed/androidgitversion/AndroidGitVersion.groovy
+++ b/src/main/groovy/com/gladed/androidgitversion/AndroidGitVersion.groovy
@@ -140,6 +140,10 @@ class AndroidGitVersionExtension {
         if (name == "unknown") return name
         name = this.format
 
+        if (results.outputOfGitDescribe != null) {
+            name = name.replace("%describe%", results.outputOfGitDescribe)
+        }
+
         def parts = [tag: results.lastVersion]
         if (results.revCount > 0) {
             parts['count'] = results.revCount

--- a/src/main/groovy/com/gladed/androidgitversion/AndroidGitVersion.groovy
+++ b/src/main/groovy/com/gladed/androidgitversion/AndroidGitVersion.groovy
@@ -41,10 +41,6 @@ class AndroidGitVersion implements Plugin<Project> {
 }
 
 class AndroidGitVersionExtension {
-    /**
-    * Option to make versionName match the expected output for those using `git describe`
-    */
-    boolean matchGitDescribe = false
 
     /**
      * Prefix used to specify special text before the tag. Useful in projects which manage
@@ -132,9 +128,6 @@ class AndroidGitVersionExtension {
      * intervening commits if any.
      */
     final String name() {
-        if (matchGitDescribe) {
-            this.format = this.format.replace("%tag%%-count%%-commit%", "%describe%")
-        }
 
         if (!results) results = scan()
 

--- a/src/main/groovy/com/gladed/androidgitversion/AndroidGitVersion.groovy
+++ b/src/main/groovy/com/gladed/androidgitversion/AndroidGitVersion.groovy
@@ -136,9 +136,6 @@ class AndroidGitVersionExtension {
 
         String name = results.lastVersion
 
-        if (matchGitDescribe) {
-            return name
-        }
 
         if (name == "unknown") return name
         name = this.format
@@ -263,8 +260,8 @@ class AndroidGitVersionExtension {
                 }.
                 last()
 
-        if (matchGitDescribe) {
-            results.lastVersion = git.describe().call()
+        if (matchGitDescribe && this.format.contains("%tag%%-count%%-commit%")) {
+            this.format = this.format.replace("%tag%%-count%%-commit%", git.describe().call())
         }
 
         results

--- a/src/main/groovy/com/gladed/androidgitversion/AndroidGitVersion.groovy
+++ b/src/main/groovy/com/gladed/androidgitversion/AndroidGitVersion.groovy
@@ -132,6 +132,10 @@ class AndroidGitVersionExtension {
      * intervening commits if any.
      */
     final String name() {
+        if (matchGitDescribe) {
+            this.format = this.format.replace("%tag%%-count%%-commit%", "%describe%")
+        }
+
         if (!results) results = scan()
 
         String name = results.lastVersion

--- a/src/main/groovy/com/gladed/androidgitversion/AndroidGitVersion.groovy
+++ b/src/main/groovy/com/gladed/androidgitversion/AndroidGitVersion.groovy
@@ -42,6 +42,11 @@ class AndroidGitVersion implements Plugin<Project> {
 
 class AndroidGitVersionExtension {
     /**
+    * Option to make versionName match the expected output for those using `git describe`
+    */
+    boolean matchGitDescribe = false
+
+    /**
      * Prefix used to specify special text before the tag. Useful in projects which manage
      * multiple external version names.
      */
@@ -130,6 +135,10 @@ class AndroidGitVersionExtension {
         if (!results) results = scan()
 
         String name = results.lastVersion
+
+        if (matchGitDescribe) {
+            return name
+        }
 
         if (name == "unknown") return name
         name = this.format
@@ -253,6 +262,10 @@ class AndroidGitVersionExtension {
                         .findResult{ x,y-> x<=>y ?: null } ?: b.size() <=> a.size()
                 }.
                 last()
+
+        if (matchGitDescribe) {
+            results.lastVersion = git.describe().call()
+        }
 
         results
     }

--- a/src/main/groovy/com/gladed/androidgitversion/AndroidGitVersion.groovy
+++ b/src/main/groovy/com/gladed/androidgitversion/AndroidGitVersion.groovy
@@ -260,9 +260,7 @@ class AndroidGitVersionExtension {
                 }.
                 last()
 
-        if (matchGitDescribe && this.format.contains("%tag%%-count%%-commit%")) {
-            this.format = this.format.replace("%tag%%-count%%-commit%", git.describe().call())
-        }
+        results.outputOfGitDescribe = git.describe().call()
 
         results
     }

--- a/src/main/groovy/com/gladed/androidgitversion/AndroidGitVersion.groovy
+++ b/src/main/groovy/com/gladed/androidgitversion/AndroidGitVersion.groovy
@@ -407,6 +407,9 @@ class AndroidGitVersionExtension {
         /** Most recent version seen */
         String lastVersion = 'unknown'
 
+        /** The resulting output from calling git describe */
+        String outputOfGitDescribe = null
+
         List getVersionParts(int parts) {
             List<String> empties = (1..parts).collect { "0" }
             return (!lastVersion ? empties : lastVersion.

--- a/src/test/groovy/com/gladed/androidgitversion/FormatTest.groovy
+++ b/src/test/groovy/com/gladed/androidgitversion/FormatTest.groovy
@@ -31,7 +31,6 @@ class FormatTest extends AndroidGitVersionTest {
     }
 
     void testBranchNameOnGitDescribe() {
-        plugin.matchGitDescribe = true
         addCommit()
         addTag("1.0")
         addBranch("feature-foo")
@@ -43,7 +42,6 @@ class FormatTest extends AndroidGitVersionTest {
     }
 
     void testDirtyOnGitDescribe() {
-        plugin.matchGitDescribe = true
         addCommit()
         addTag("1.0")
         new File(projectFolder.root, "build.gradle").append("// addition 2") // Dirty
@@ -52,7 +50,6 @@ class FormatTest extends AndroidGitVersionTest {
     }
 
     void testDirtyBranchOnGitDescribe() {
-        this.plugin.matchGitDescribe = true
         addCommit()
         addTag("1.0")
         addBranch("release/1.x")

--- a/src/test/groovy/com/gladed/androidgitversion/FormatTest.groovy
+++ b/src/test/groovy/com/gladed/androidgitversion/FormatTest.groovy
@@ -30,6 +30,40 @@ class FormatTest extends AndroidGitVersionTest {
         assert plugin.name().endsWith(').release_1.x')
     }
 
+    void testBranchNameOnGitDescribe() {
+        plugin.matchGitDescribe = true
+        addCommit()
+        addTag("1.0")
+        addBranch("feature-foo")
+        new File(projectFolder.root, "build.gradle").append("// addition 1")
+        addCommit()
+
+        assert plugin.name().startsWith('1.0-1-g')
+        assert plugin.name().endsWith('-feature-foo')
+    }
+
+    void testDirtyOnGitDescribe() {
+        plugin.matchGitDescribe = true
+        addCommit()
+        addTag("1.0")
+        new File(projectFolder.root, "build.gradle").append("// addition 2") // Dirty
+
+        assert plugin.name().equals("1.0-dirty")
+    }
+
+    void testDirtyBranchOnGitDescribe() {
+        this.plugin.matchGitDescribe = true
+        addCommit()
+        addTag("1.0")
+        addBranch("release/1.x")
+        new File(projectFolder.root, "build.gradle").append("// addition 1")
+        addCommit()
+        new File(projectFolder.root, "build.gradle").append("// addition 2") // Dirty
+
+        assert plugin.name().startsWith('1.0-1-g')
+        assert plugin.name().endsWith('release_1.x-dirty')
+    }
+
     void testLongCommitHash() {
         addCommit()
         addTag("1.4")

--- a/src/test/groovy/com/gladed/androidgitversion/FormatTest.groovy
+++ b/src/test/groovy/com/gladed/androidgitversion/FormatTest.groovy
@@ -36,6 +36,7 @@ class FormatTest extends AndroidGitVersionTest {
         addBranch("feature-foo")
         new File(projectFolder.root, "build.gradle").append("// addition 1")
         addCommit()
+        plugin.format = "%describe%%-branch%%-dirty%"
 
         assert plugin.name().startsWith('1.0-1-g')
         assert plugin.name().endsWith('-feature-foo')
@@ -45,6 +46,7 @@ class FormatTest extends AndroidGitVersionTest {
         addCommit()
         addTag("1.0")
         new File(projectFolder.root, "build.gradle").append("// addition 2") // Dirty
+        plugin.format = "%describe%%-branch%%-dirty%"
 
         assert plugin.name().equals("1.0-dirty")
     }
@@ -56,6 +58,7 @@ class FormatTest extends AndroidGitVersionTest {
         new File(projectFolder.root, "build.gradle").append("// addition 1")
         addCommit()
         new File(projectFolder.root, "build.gradle").append("// addition 2") // Dirty
+        plugin.format = "%describe%%-branch%%-dirty%"
 
         assert plugin.name().startsWith('1.0-1-g')
         assert plugin.name().endsWith('release_1.x-dirty')

--- a/src/test/groovy/com/gladed/androidgitversion/MainTest.groovy
+++ b/src/test/groovy/com/gladed/androidgitversion/MainTest.groovy
@@ -161,6 +161,19 @@ class MainTest extends AndroidGitVersionTest {
         assertTrue("untracked is dirty", plugin.name().contains("dirty"))
     }
 
+    void testMatchGitDescribeOffByDefault() {
+        addCommit()
+        addTag("1.0.0")
+        def currentCommit = addCommit()
+        def currentHash = ObjectId.toString(currentCommit.toObjectId())
+        def shortHash = currentHash.substring(0, 7)
+        def expectedVersionName = "1.0.0-1-" + shortHash
+        def versionName = plugin.name()
+        assert versionName.startsWith("1.0.0-1-")
+        assert versionName.endsWith(shortHash)
+        assertEquals (expectedVersionName, versionName)
+    }
+
     void testMatchGitDescribeUsesCorrectCommit() {
         plugin.matchGitDescribe = true
         addCommit()

--- a/src/test/groovy/com/gladed/androidgitversion/MainTest.groovy
+++ b/src/test/groovy/com/gladed/androidgitversion/MainTest.groovy
@@ -175,7 +175,6 @@ class MainTest extends AndroidGitVersionTest {
     }
 
     void testMatchGitDescribeUsesCorrectCommit() {
-        plugin.matchGitDescribe = true
         addCommit()
         addTag("1.0.0")
         def currentCommit = addCommit()

--- a/src/test/groovy/com/gladed/androidgitversion/MainTest.groovy
+++ b/src/test/groovy/com/gladed/androidgitversion/MainTest.groovy
@@ -1,6 +1,7 @@
 package com.gladed.androidgitversion
 
 import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.lib.ObjectId
 import org.eclipse.jgit.lib.Repository
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
@@ -158,6 +159,20 @@ class MainTest extends AndroidGitVersionTest {
         File file = new File(projectFolder.root, "untracked.file");
         file.append("content");
         assertTrue("untracked is dirty", plugin.name().contains("dirty"))
+    }
+
+    void testMatchGitDescribeUsesCorrectCommit() {
+        plugin.matchGitDescribe = true
+        addCommit()
+        addTag("1.0.0")
+        def currentCommit = addCommit()
+        def currentHash = ObjectId.toString(currentCommit.toObjectId())
+        def shortHash = currentHash.substring(0, 7)
+        def expectedVersionName = "1.0.0-1-g" + shortHash
+        def versionName = plugin.name()
+        assert versionName.startsWith("1.0.0-1-g")
+        assert versionName.endsWith(shortHash)
+        assertEquals (expectedVersionName, versionName)
     }
 
     void testFlush() {

--- a/src/test/groovy/com/gladed/androidgitversion/MainTest.groovy
+++ b/src/test/groovy/com/gladed/androidgitversion/MainTest.groovy
@@ -181,6 +181,8 @@ class MainTest extends AndroidGitVersionTest {
         def currentHash = ObjectId.toString(currentCommit.toObjectId())
         def shortHash = currentHash.substring(0, 7)
         def expectedVersionName = "1.0.0-1-g" + shortHash
+        plugin.format = "%describe%%-branch%%-dirty%"
+
         def versionName = plugin.name()
         assert versionName.startsWith("1.0.0-1-g")
         assert versionName.endsWith(shortHash)


### PR DESCRIPTION
To take the concept of "match git describe" one step further, this PR makes some further improvements on top of #73 by making the functionality available via two different options:

- Set matchGitDescribe to true 
    - A) Include the letter 'g' in the versionName (resolves issue #66)
    - B) Use the rev count calculated by git (resolves issue #67)
- Insert the string `"%describe%"` anywhere within their `format` (resolves issues called out in #68)

The first option should allow for ease of use so that users expecting the output to match `git describe` (but with no need or desire to modify their format) can simply configure the plugin with a simple boolean toggle.

The second option should allow for flexibility so that anyone who ***does*** want to modify their format has the ability to do so while still matching `git describe`

Note: There is technically no need to set `matchGitDescribe` to true once `"%describe%"` has been added into `format`. This may be confusing to some as they may wonder whether it makes a difference or not. Therefore, we may decide to somehow evolve this PR further to clear up any possible confusion, or it could simply be left for an additional change later down the road.